### PR TITLE
Improvements to the Installer Generator & Continuous Delivery 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         with:
-          args: deploy
+          args: deploy --project installer-to
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
       - name: Deploy to Google Cloud Bucket

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
       - name: Deploy to Google Cloud Bucket
-      - uses: actions-hub/gcloud@master
+        uses: actions-hub/gcloud@master
         env:
           PROJECT_ID: installer-to
           APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@master
-      - name: Get the list of modified files only & Generate installers
+      - name: Get the list of modified files only
         uses: technote-space/get-diff-action@v1
+      - name: Generate installers
         run: pip install toml && python generate.py ${{ env.GIT_DIFF }}
       - name: Archive Production Artifact
         uses: actions/upload-artifact@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,14 @@ jobs:
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         with:
-          args: deploy --only storage
+          args: deploy
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+      - name: Deploy to Google Cloud Bucket
+      - uses: actions-hub/gcloud@master
+        env:
+          PROJECT_ID: installer-to
+          APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+        with:
+          args: rsync -r installers gs://installer-to/installers
+          cli: gsutil

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,5 +46,5 @@ jobs:
           PROJECT_ID: installer-to
           APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
         with:
-          args: rsync -r installers gs://installer-to/installers
+          args: rsync -r installers gs://installer-to.appspot.com/installers
           cli: gsutil

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           name: installers
           path: installers
+      - name: Install Dependencies
+        run: cd functions && npm install
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Build and Deploy
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+      - name: Get the list of modified files only & Generate installers
+        uses: technote-space/get-diff-action@v1
+        run: pip install toml && python generate.py ${{ env.GIT_DIFF }}
+      - name: Archive Production Artifact
+        uses: actions/upload-artifact@master
+        with:
+          name: installers
+          path: installers
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+      - name: Download Artifact
+        uses: actions/download-artifact@master
+        with:
+          name: installers
+          path: installers
+      - name: Deploy to Firebase
+        uses: w9jds/firebase-action@master
+        with:
+          args: deploy --only storage
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/installers/dunner/installer.toml
+++ b/installers/dunner/installer.toml
@@ -1,3 +1,5 @@
+
+
 [apt]
 sh = """
 echo "Installing hello"
@@ -10,11 +12,6 @@ echo "Installing hello"
 echo "Installed hello"
 """
 
-[pacman]
-sh = """
-echo "Installing hello"
-echo "Installed hello"
-"""
 
 [apk]
 sh = """

--- a/installers/git/installer.sh
+++ b/installers/git/installer.sh
@@ -1,16 +1,18 @@
 #!/bin/sh
-
+      
 YUM_CMD=$(which yum) # yum package manager for RHEL & CentOS
 DNF_CMD=$(which dnf) # dnf package manager for new RHEL & CentOS
 APT_GET_CMD=$(which apt-get) # apt package manager for Ubuntu & other Debian based distributions
 PACMAN_CMD=$(which pacman) # pacman package manager for ArchLinux
 APK_CMD=$(which apk) # apk package manager for Alpine
+GIT_CMD=$(which git) # to build from source pulling from git
+SUDO_CMD=$(which sudo) # check if sudo command is there
 
 USER="$(id -un 2>/dev/null || true)"
-PREFIX=''
+SUDO=''
 if [ "$USER" != 'root' ]; then
-	if command_exists sudo; then
-		PREFIX='sudo'
+	if [ ! -z $SUDO_CMD ]; then
+		SUDO='sudo'
 	else
 		cat >&2 <<-'EOF'
 		Error: this installer needs the ability to run commands as root.
@@ -20,20 +22,25 @@ if [ "$USER" != 'root' ]; then
 	fi
 fi
 
- if [ ! -z $APT_GET_CMD ]; then
-    $PREFIX apt-get update
-    $PREFIX apt-get install git
- elif [ ! -z $DNF_CMD ]; then
-    $PREFIX dnf install git
- elif [ ! -z $YUM_CMD ]; then
-    $PREFIX yum install git
- elif [ ! -z $PACMAN_CMD ]; then
-    pacman -Sy git
- elif [ ! -z $APK_CMD ]; then
-    $PREFIX apk add git
- else
-    echo "Couldn't find an installer matching to this package"
-    exit 1;
- fi
+echo $SUDO
 
-git --version
+if [ ! -z $APT_GET_CMD ]; then
+   $SUDO apt-get update
+   $SUDO apt-get install git
+   
+elif [ ! -z $YUM_CMD ]; then
+   $SUDO yum install git
+   
+elif [ ! -z $PACMAN_CMD ]; then
+   pacman -Sy git
+   
+elif [ ! -z $DNF_CMD ]; then
+   $SUDO dnf install git
+   
+elif [ ! -z $APK_CMD ]; then
+   $SUDO apk add git
+   
+else
+   echo "Couldn't install package"
+   exit 1;
+fi

--- a/installers/git/installer.toml
+++ b/installers/git/installer.toml
@@ -1,12 +1,12 @@
 [apt]
 sh = """
-sudo apt-get update
-sudo apt-get install git
+@sudo apt-get update
+@sudo apt-get install git
 """
 
 [yum]
 sh = """
-sudo yum install git
+@sudo yum install git
 """
 
 [pacman]
@@ -16,10 +16,10 @@ pacman -Sy git
 
 [dnf]
 sh = """
-sudo dnf install git
+@sudo dnf install git
 """
 
 [apk]
 sh = """
-sudo apk add git
+@sudo apk add git
 """

--- a/installers/git/installer.toml
+++ b/installers/git/installer.toml
@@ -1,0 +1,25 @@
+[apt]
+sh = """
+sudo apt-get update
+sudo apt-get install git
+"""
+
+[yum]
+sh = """
+sudo yum install git
+"""
+
+[pacman]
+sh = """
+pacman -Sy git
+"""
+
+[dnf]
+sh = """
+sudo dnf install git
+"""
+
+[apk]
+sh = """
+sudo apk add git
+"""

--- a/installers/hello/installer.sh
+++ b/installers/hello/installer.sh
@@ -1,3 +1,29 @@
 #!/bin/sh
+      
+YUM_CMD=$(which yum) # yum package manager for RHEL & CentOS
+DNF_CMD=$(which dnf) # dnf package manager for new RHEL & CentOS
+APT_GET_CMD=$(which apt-get) # apt package manager for Ubuntu & other Debian based distributions
+PACMAN_CMD=$(which pacman) # pacman package manager for ArchLinux
+APK_CMD=$(which apk) # apk package manager for Alpine
+GIT_CMD=$(which git) # to build from source pulling from git
 
-echo "Hello!"
+if [ ! -z $APT_GET_CMD ]; then
+   echo "Installing hello"
+   echo "Installed hello"
+   
+elif [ ! -z $YUM_CMD ]; then
+   echo "Installing hello"
+   echo "Installed hello"
+   
+elif [ ! -z $APK_CMD ]; then
+   echo "Installing hello"
+   echo "Installed hello"
+   
+elif [ ! -z $DNF_CMD ]; then
+   echo "Installing hello"
+   echo "Installed hello"
+   
+else
+   echo "Couldn't install package"
+   exit 1;
+fi

--- a/installers/hello/spec/hello_spec.sh
+++ b/installers/hello/spec/hello_spec.sh
@@ -2,7 +2,7 @@ Describe "Installer script for"
   Describe "hello"
     It "should say hello!"
       When call installers/hello/installer.sh
-      The output should eq "Hello!"
+      The output should include "Installed"
     End
   End
 End

--- a/installers/nginx/installer.sh
+++ b/installers/nginx/installer.sh
@@ -1,26 +1,30 @@
 #!/bin/sh
-
+      
 YUM_CMD=$(which yum) # yum package manager for RHEL & CentOS
 DNF_CMD=$(which dnf) # dnf package manager for new RHEL & CentOS
 APT_GET_CMD=$(which apt-get) # apt package manager for Ubuntu & other Debian based distributions
 PACMAN_CMD=$(which pacman) # pacman package manager for ArchLinux
 APK_CMD=$(which apk) # apk package manager for Alpine
+GIT_CMD=$(which git) # to build from source pulling from git
 
- if [ ! -z $APT_GET_CMD ]; then
-    sudo apt-get update
-    sudo apt-get install nginx
- elif [ ! -z $DNF_CMD ]; then
-    sudo dnf install nginx
- elif [ ! -z $YUM_CMD ]; then
-    sudo yum install nginx
- elif [ ! -z $PACMAN_CMD ]; then
-    sudo pacman -S nginx
- elif [ 1 -z $APK_CMD ]; then
-    sudo apk update
-    sudo apk add nginx
- else
-    echo "Couldn't install package"
-    exit 1;
- fi
-
-nginx -v
+if [ ! -z $APT_GET_CMD ]; then
+   sudo apt-get update
+   sudo apt-get install nginx
+   
+elif [ ! -z $YUM_CMD ]; then
+   sudo yum install nginx
+   
+elif [ ! -z $PACMAN_CMD ]; then
+   sudo pacman -S nginx
+   
+elif [ ! -z $APK_CMD ]; then
+   sudo apk update
+   sudo apk add nginx
+   
+elif [ ! -z $DNF_CMD ]; then
+   sudo dnf install nginx
+   
+else
+   echo "Couldn't install package"
+   exit 1;
+fi

--- a/installers/nginx/installer.toml
+++ b/installers/nginx/installer.toml
@@ -1,0 +1,26 @@
+[apt]
+sh = """
+sudo apt-get update
+sudo apt-get install nginx
+"""
+
+[yum]
+sh = """
+sudo yum install nginx
+"""
+
+[pacman]
+sh = """
+@sudo pacman -S nginx
+"""
+
+[apk]
+sh = """
+sudo apk update
+sudo apk add nginx
+"""
+
+[dnf]
+sh = """
+sudo dnf install nginx
+"""

--- a/installers/node/installer.sh
+++ b/installers/node/installer.sh
@@ -1,30 +1,34 @@
 #!/bin/sh
-
+      
 YUM_CMD=$(which yum) # yum package manager for RHEL & CentOS
 DNF_CMD=$(which dnf) # dnf package manager for new RHEL & CentOS
 APT_GET_CMD=$(which apt-get) # apt package manager for Ubuntu & other Debian based distributions
+PACMAN_CMD=$(which pacman) # pacman package manager for ArchLinux
 APK_CMD=$(which apk) # apk package manager for Alpine
+GIT_CMD=$(which git) # to build from source pulling from git
 
- if [ ! -z $APT_GET_CMD ]; then
-    if [  -n "$(uname -a | grep Ubuntu)" ]; then
-        curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-        sudo apt-get install -y nodejs
-    else
-        curl -sL https://deb.nodesource.com/setup_12.x | bash -
-        sudo apt-get install -y nodejs
-    fi  
- elif [ ! -z $DNF_CMD ]; then
-    sudo dnf install -y gcc-c++ make
-    curl -sL https://rpm.nodesource.com/setup_12.x | sudo -E bash -
-    sudo dnf install nodejs
- elif [ ! -z $YUM_CMD ]; then
-    sudo yum install nodejs12
- elif [ 1 -z $APK_CMD ]; then
-    sudo apk update
-    sudo apk add nodejs
- else
-    echo "Couldn't install package"
-    exit 1;
- fi
-
-node --version
+if [ ! -z $APT_GET_CMD ]; then
+   if [  -n "$(uname -a | grep Ubuntu)" ]; then
+       curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+       sudo apt-get install -y nodejs
+   else
+       curl -sL https://deb.nodesource.com/setup_12.x | bash -
+       sudo apt-get install -y nodejs
+   fi
+   
+elif [ ! -z $YUM_CMD ]; then
+   sudo yum install nodejs12
+   
+elif [ ! -z $DNF_CMD ]; then
+   sudo dnf install -y gcc-c++ make
+   curl -sL https://rpm.nodesource.com/setup_12.x | sudo -E bash -
+   sudo dnf install nodejs
+   
+elif [ ! -z $APK_CMD ]; then
+   sudo apk update
+   sudo apk add nodejs
+   
+else
+   echo "Couldn't install package"
+   exit 1;
+fi

--- a/installers/node/installer.toml
+++ b/installers/node/installer.toml
@@ -1,0 +1,28 @@
+[apt]
+sh = """
+if [  -n "$(uname -a | grep Ubuntu)" ]; then
+    curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+else
+    curl -sL https://deb.nodesource.com/setup_12.x | bash -
+    sudo apt-get install -y nodejs
+fi
+"""
+
+[yum]
+sh = """
+sudo yum install nodejs12
+"""
+
+[dnf]
+sh = """
+sudo dnf install -y gcc-c++ make
+curl -sL https://rpm.nodesource.com/setup_12.x | sudo -E bash -
+sudo dnf install nodejs
+"""
+
+[apk]
+sh = """
+sudo apk update
+sudo apk add nodejs
+"""

--- a/installers/python3/installer.sh
+++ b/installers/python3/installer.sh
@@ -1,25 +1,30 @@
 #!/bin/sh
-
+      
 YUM_CMD=$(which yum) # yum package manager for RHEL & CentOS
 DNF_CMD=$(which dnf) # dnf package manager for new RHEL & CentOS
 APT_GET_CMD=$(which apt-get) # apt package manager for Ubuntu & other Debian based distributions
 PACMAN_CMD=$(which pacman) # pacman package manager for ArchLinux
 APK_CMD=$(which apk) # apk package manager for Alpine
+GIT_CMD=$(which git) # to build from source pulling from git
+SUDO_CMD=$(which sudo) # check if sudo command is there
 
- if [ ! -z $APT_GET_CMD ]; then
-    sudo apt-get update
-    sudo apt-get install python3
- elif [ ! -z $DNF_CMD ]; then
-    sudo dnf install python3
- elif [ ! -z $YUM_CMD ]; then
-    sudo yum install python3
- elif [ ! -z $PACMAN_CMD ]; then
-    pacman -Sy python3
- elif [ ! -z $APK_CMD ]; then
-    sudo apk add python3
- else
-    echo "Couldn't install package"
-    exit 1;
- fi
-
-python3 --version
+if [ ! -z $APT_GET_CMD ]; then
+   sudo apt-get update
+   sudo apt-get install python3
+   
+elif [ ! -z $YUM_CMD ]; then
+   sudo yum install python3
+   
+elif [ ! -z $PACMAN_CMD ]; then
+   pacman -Sy python3
+   
+elif [ ! -z $APK_CMD ]; then
+   sudo apk add python3
+   
+elif [ ! -z $DNF_CMD ]; then
+   sudo dnf install python3
+   
+else
+   echo "Couldn't install package"
+   exit 1;
+fi

--- a/installers/python3/installer.toml
+++ b/installers/python3/installer.toml
@@ -1,0 +1,25 @@
+[apt]
+sh = """
+sudo apt-get update
+sudo apt-get install python3
+"""
+
+[yum]
+sh = """
+sudo yum install python3
+"""
+
+[pacman]
+sh = """
+pacman -Sy python3
+"""
+
+[apk]
+sh = """
+sudo apk add python3
+"""
+
+[dnf]
+sh = """
+sudo dnf install python3
+"""


### PR DESCRIPTION
I'm adding a few more `installer.toml`s here. Also now anyone can use the `@sudo` keyword in the installer steps. The generated script will check if `sudo` is needed and add only if the user is not root user and the user has `sudo` in the system. 

Also, this will upload the generated installer scripts to cloud storage bucket and deploy Firebase functions and hosting.