### PR TITLE
Adding automatic PR creation for generated README.md & installers.toml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,13 @@ jobs:
         run: pip install toml && python generate.py ${{ env.GIT_DIFF }}
       - name: Minify generated installers
         run: ./minify.sh ${{ env.GIT_DIFF }}
+      - name: Create a pull request for README.md & installers.toml updates
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: update README.md & installers.toml
+          title: Update README.md & installers.toml
+          body: Update README.md & installers.toml for the changes to the installer scripts
+          branch: update-readme-md-and-installers-toml
       - name: Archive Production Artifact
         uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,13 +13,18 @@ jobs:
         uses: actions/checkout@master
       - name: Get the list of modified files only
         uses: technote-space/get-diff-action@v1
+        with:
+          PREFIX_FILTER: |
+            installers
       - name: Generate installers, update README.md & installers.toml
         run: |
           pip install toml
           pip install pytablewriter
           python generate.py ${{ env.GIT_DIFF }}
+        if: env.GIT_DIFF
       - name: Minify generated installers
         run: ./minify.sh ${{ env.GIT_DIFF }}
+        if: env.GIT_DIFF
       - name: Create a pull request for README.md & installers.toml updates
         uses: peter-evans/create-pull-request@v3
         with:
@@ -27,11 +32,14 @@ jobs:
           title: Update README.md & installers.toml
           body: Update README.md & installers.toml for the changes to the installer scripts
           branch: update-readme-md-and-installers-toml
+        if: env.GIT_DIFF
       - name: Archive Production Artifact
         uses: actions/upload-artifact@master
         with:
           name: installers
           path: installers
+        if: env.GIT_DIFF
+
   deploy:
     name: Deploy
     needs: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,16 +61,16 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@master
       - name: Get the list of modified installers only
-      uses: technote-space/get-diff-action@v1
-      with:
-        PREFIX_FILTER: |
-          installers
+        uses: technote-space/get-diff-action@v1
+        with:
+          PREFIX_FILTER: |
+            installers
       - name: Download Artifact
+        if: env.GIT_DIFF
         uses: actions/download-artifact@master
         with:
           name: installers
           path: installers
-        if: env.GIT_DIFF
       - name: Install Dependencies
         run: cd functions && npm install
       - name: Deploy to Firebase

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: update README.md & installers.toml
-          title: Update installer scrits, README.md & installers.toml
+          title: Update installer scripts, README.md & installers.toml
           body: |
             Update README.md & installers.toml for the changes to the installer scripts.
             This is a generated PR in related to PR ${{ steps.vars.outputs.pr_id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,19 +33,20 @@ jobs:
         id: vars
         run: |
           echo "The related PR is ${PR}"
-          echo ::set-output name=pr_id::"#${PR}"
+          echo ::set-output name=pr_id::"${PR}"
         env:
           PR: ${{ steps.findPr.outputs.pr }}
       - name: Create a pull request for README.md & installers.toml updates
         if: env.GIT_DIFF
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: update README.md & installers.toml
-          title: Update installer scripts, README.md & installers.toml
+          commit-message: Update installer scripts, README.md & installers.toml
+          title: Update installer scripts, README.md & installers.toml for #${{ steps.vars.outputs.pr_id }}
           body: |
-            Update README.md & installers.toml for the changes to the installer scripts.
-            This is a generated PR in related to PR ${{ steps.vars.outputs.pr_id }}
+            Updated installer scripts, `README.md` & `installers.toml` according to the changes done in the `installer.toml`s.
+            This is a automatically generated PR in related to PR #${{ steps.vars.outputs.pr_id }}
           branch: update-readme-md-and-installers-toml-${{ steps.vars.outputs.pr_id }}
+          labels: automated-pr, continious-delivery
       - name: Archive Production Artifact
         if: env.GIT_DIFF
         uses: actions/upload-artifact@master
@@ -64,7 +65,7 @@ jobs:
         uses: technote-space/get-diff-action@v1
         with:
           PREFIX_FILTER: |
-            installers
+            installers/
       - name: Download Artifact
         if: env.GIT_DIFF
         uses: actions/download-artifact@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,11 @@ jobs:
         uses: actions/checkout@master
       - name: Get the list of modified files only
         uses: technote-space/get-diff-action@v1
-      - name: Generate installers
-        run: pip install toml && python generate.py ${{ env.GIT_DIFF }}
+      - name: Generate installers, update README.md & installers.toml
+        run: |
+          pip install toml
+          pip install pytablewriter
+          python generate.py ${{ env.GIT_DIFF }}
       - name: Minify generated installers
         run: ./minify.sh ${{ env.GIT_DIFF }}
       - name: Create a pull request for README.md & installers.toml updates

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
         uses: technote-space/get-diff-action@v1
         with:
           PREFIX_FILTER: |
-            installers
+            installers/
       - name: Generate installers, update README.md & installers.toml
         if: env.GIT_DIFF
         run: ./generate.sh ${{ env.GIT_DIFF }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,31 +11,47 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@master
-      - name: Get the list of modified files only
+      - name: Get the list of modified installers only
         uses: technote-space/get-diff-action@v1
         with:
           PREFIX_FILTER: |
             installers
       - name: Generate installers, update README.md & installers.toml
+        if: env.GIT_DIFF
         run: ./generate.sh ${{ env.GIT_DIFF }}
-        if: env.GIT_DIFF
       - name: Minify generated installers
-        run: ./minify.sh ${{ env.GIT_DIFF }}
         if: env.GIT_DIFF
+        run: ./minify.sh ${{ env.GIT_DIFF }}
+      - name: Find the Related PR
+        if: env.GIT_DIFF
+        uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Related PR
+        if:  env.GIT_DIFF && success() && steps.findPr.outputs.number
+        id: vars
+        run: |
+          echo "The related PR is ${PR}"
+          echo ::set-output name=pr_body::"#${PR}"
+        env:
+          PR: ${{ steps.findPr.outputs.pr }}
       - name: Create a pull request for README.md & installers.toml updates
+        if: env.GIT_DIFF
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: update README.md & installers.toml
-          title: Update README.md & installers.toml
-          body: Update README.md & installers.toml for the changes to the installer scripts
+          title: Update installer scrits, README.md & installers.toml
+          body: |
+            Update README.md & installers.toml for the changes to the installer scripts.
+            This is a generated PR in related to PR ${{ steps.vars.outputs.pr_body }}
           branch: update-readme-md-and-installers-toml
-        if: env.GIT_DIFF
       - name: Archive Production Artifact
+        if: env.GIT_DIFF
         uses: actions/upload-artifact@master
         with:
           name: installers
           path: installers
-        if: env.GIT_DIFF
 
   deploy:
     name: Deploy
@@ -44,11 +60,17 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@master
+      - name: Get the list of modified installers only
+      uses: technote-space/get-diff-action@v1
+      with:
+        PREFIX_FILTER: |
+          installers
       - name: Download Artifact
         uses: actions/download-artifact@master
         with:
           name: installers
           path: installers
+        if: env.GIT_DIFF
       - name: Install Dependencies
         run: cd functions && npm install
       - name: Deploy to Firebase

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,8 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: Update installer scripts, README.md & installers.toml
-          title: Update installer scripts, README.md & installers.toml for #${{ steps.vars.outputs.pr_id }}
+          title: |
+            Update installer scripts, README.md & installers.toml for #${{ steps.vars.outputs.pr_id }}
           body: |
             Updated installer scripts, `README.md` & `installers.toml` according to the changes done in the `installer.toml`s.
             This is a automatically generated PR in related to PR #${{ steps.vars.outputs.pr_id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         id: vars
         run: |
           echo "The related PR is ${PR}"
-          echo ::set-output name=pr_body::"#${PR}"
+          echo ::set-output name=pr_id::"#${PR}"
         env:
           PR: ${{ steps.findPr.outputs.pr }}
       - name: Create a pull request for README.md & installers.toml updates
@@ -44,8 +44,8 @@ jobs:
           title: Update installer scrits, README.md & installers.toml
           body: |
             Update README.md & installers.toml for the changes to the installer scripts.
-            This is a generated PR in related to PR ${{ steps.vars.outputs.pr_body }}
-          branch: update-readme-md-and-installers-toml
+            This is a generated PR in related to PR ${{ steps.vars.outputs.pr_id }}
+          branch: update-readme-md-and-installers-toml-${{ steps.vars.outputs.pr_id }}
       - name: Archive Production Artifact
         if: env.GIT_DIFF
         uses: actions/upload-artifact@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,10 +17,7 @@ jobs:
           PREFIX_FILTER: |
             installers
       - name: Generate installers, update README.md & installers.toml
-        run: |
-          pip install toml
-          pip install pytablewriter
-          python generate.py ${{ env.GIT_DIFF }}
+        run: ./generate.sh ${{ env.GIT_DIFF }}
         if: env.GIT_DIFF
       - name: Minify generated installers
         run: ./minify.sh ${{ env.GIT_DIFF }}

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,22 +1,22 @@
-
 name: Run tests
 
 on:
-
   push:
     branches: [ master ]
 
   pull_request:
     branches: [ master ]
 
-
 jobs:
 
   test-on-ubuntu:
-
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: technote-space/get-diff-action@v1
-    - name: Get the list of modified files only
-      run: pip install toml pytablewriter && python generate.py ${{ env.GIT_DIFF }} && docker build -t shellspec . && docker run -v $PWD:/app shellspec bash -c "cd /app && ./test.sh ${{ env.GIT_DIFF }}"
+      - uses: actions/checkout@v2
+      - uses: technote-space/get-diff-action@v1
+      - name: Run tests for the modified/ added files
+        run: |
+          pip install toml pytablewriter
+          python generate.py ${{ env.GIT_DIFF }}
+          docker build -t shellspec .
+          docker run -v $PWD:/app shellspec bash -c "cd /app && ./test.sh ${{ env.GIT_DIFF }}"

--- a/generate.py
+++ b/generate.py
@@ -31,7 +31,7 @@ def update_readme(summary):
         curl = "Yes" if "curl" in installers else "No"
         url = "https://installer.to/"+tool_shortname
         value_matrix.append([name, apt, yum, pacman, apk, dnf, curl, url])
-    print(value_matrix)
+
     writer.value_matrix = value_matrix
     table_md = writer.dumps()
     try:
@@ -46,23 +46,20 @@ def update_readme(summary):
             readme_md.write(readme)
             readme_md.close()
     except Error as e:
-        print(e)
+        logging.error('Error occurred when trying to update README.md, error: '+ e)
 
 
 def update_summary(name, shortname, description, installers):
     try:
         with open("./installers.toml", "r+") as installer_summary:
             summaary = installer_summary.read()
-            print (summaary)
             parsed_summary_toml = toml.loads(summaary)
-            print (parsed_summary_toml)
             if shortname not in parsed_summary_toml:
                 parsed_summary_toml[shortname] = {}
             parsed_summary_toml[shortname]['name'] = name
             parsed_summary_toml[shortname]['name'] = name
             parsed_summary_toml[shortname]['description'] = description
             parsed_summary_toml[shortname]['installers'] = ",".join(installers)
-            print (parsed_summary_toml)
             installer_summary.seek(0)  # sets  point at the beginning of the file
             installer_summary.truncate()  # Clear previous content
             installer_summary.write(toml.dumps(parsed_summary_toml))
@@ -70,8 +67,7 @@ def update_summary(name, shortname, description, installers):
 
             update_readme(parsed_summary_toml)
     except IOError as e:
-        print ("Error", e)
-        pass
+        logging.error('Error occurred when trying to update installers.toml, error: '+ e)
 
 def get_method_case(method):
    if method in methods:
@@ -167,7 +163,6 @@ fi
 
       installer_sh.close()
       update_summary(parsed_toml['name'], parsed_toml['shortname'], parsed_toml['description'], installer_methods)
-      print("installer_methods",installer_methods)
 
    except IOError as x:
       if x.errno == errno.EACCES:

--- a/generate.sh
+++ b/generate.sh
@@ -9,7 +9,6 @@ done
 CHANGED=$(echo $X | tr ' ' '\n' | sort | uniq | xargs)
 
 echo "generating for $CHANGED"
-#shellspec $CHANGED
-#pip install toml
-#pip install pytablewriter
+pip install toml
+pip install pytablewriter
 python generate.py $CHANGED

--- a/generate.sh
+++ b/generate.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+X=()
+
+for word in "$@"; do
+  X+=$(dirname "$word " | cut -d "/" -f "1 2")" "
+done
+
+CHANGED=$(echo $X | tr ' ' '\n' | sort | uniq | xargs)
+
+echo "generating for $CHANGED"
+#shellspec $CHANGED
+#pip install toml
+#pip install pytablewriter
+python generate.py $CHANGED

--- a/installers/hlf/installer.toml
+++ b/installers/hlf/installer.toml
@@ -7,17 +7,16 @@ description = "Hyperledger Fabric"
 sh = """
 if ! command -v docker
 then
-    @warn "docker could not be found"
+    @warn "Docker could not be found"
     curl https://installer.to/docker | bash
 else
-    @info "docker found"
+    @info "Docker found"
 fi
 
-@info "downloading Fabric........"
+@info "Downloading Fabric........"
 curl -sSL http://bit.ly/2ysbOFE -o bootstrap.sh
 chmod 755 ./bootstrap.sh
 @sudo bash ./bootstrap.sh
 
 @sudo cp ./fabric-samples/bin/*    /usr/local/bin
-
 """


### PR DESCRIPTION
With this PR, the Continuous Delivery part of the installers completes. Now when a someone creates a PR with a new `installer.toml` file for a tool and gets it merged, the GitHub Actions will generate the `installer.sh`, `installer.min.sh` then updates the `README.md` and `installers.toml` with a summary.

Sample PR from someone: https://github.com/Heshdude/installer.to/pull/43  ( only `installer.toml` file )
Auto generated PR: https://github.com/Heshdude/installer.to/pull/44 (  `installer.sh`, `installer.min.sh`, `README.md` and `installers.toml` )