### PR TITLE
Platform specific installers

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -25,12 +25,13 @@ app.get('/:package', (req, res) => {
         const withParam = req.query.with;
         const fileName = ['installer'];
 
-        if (minParam){
-            fileName.push('min');
-        }
         if (withParam){
             fileName.push(withParam);
         }
+        if (minParam){
+            fileName.push('min');
+        }
+
         fileName.push('sh');
         const fileNameString = fileName.join(".");
         const file = bucket.file(req.params.package + '/'+fileNameString);

--- a/functions/index.js
+++ b/functions/index.js
@@ -10,12 +10,30 @@ const storage = new Storage();
 const bucket = storage.bucket('installer-to.appspot.com');
 
 app.get('/', (req, res) => {
-  res.json({ status: 'OK' });
+    res.set('Content-Type', 'application/json');
+    res.json({ status: 'OK' });
+});
+
+app.get('/health', (req, res) => {
+    res.set('Content-Type', 'application/json');
+    res.json({ status: 'OK' });
 });
 
 app.get('/:package', (req, res) => {
     try {
-        const file = bucket.file(req.params.package + '/installer.sh');
+        const minParam = req.query.min;
+        const withParam = req.query.with;
+        const fileName = ['installer'];
+
+        if (minParam){
+            fileName.push('min');
+        }
+        if (withParam){
+            fileName.push(withParam);
+        }
+        fileName.push('sh');
+        const fileNameString = fileName.join(".");
+        const file = bucket.file(req.params.package + '/'+fileNameString);
         res.set('Content-Type', 'text/plain');
         const readStream = file.createReadStream();
         readStream.pipe(res);

--- a/generate.py
+++ b/generate.py
@@ -151,6 +151,8 @@ def generate_individual_installers(method, lines):
     installer_sh_path = path + "/installer."+method+".sh"
     try:
         with open(installer_sh_path, "w") as installer_sh:
+            installer_sh.write("""#!/bin/sh
+""")
             write_sudo_fix_commands(installer_sh)
             write_logger_commands(installer_sh)
             write_installer_commands(installer_sh, lines)

--- a/minify.sh
+++ b/minify.sh
@@ -8,9 +8,18 @@ done
 
 CHANGED=$(echo $X | tr ' ' '\n' | sort | uniq | xargs)
 
-echo "minifying $CHANGED"
+echo "Minifying $CHANGED"
 #shellspec $CHANGED
 
-for word in $CHANGED; do
-  ./minifier.sh -f="$word/installer.sh" > "$word/installer.min.sh"
+for directory in $CHANGED; do
+  echo "Minifying direcory is: $directory"
+  for file in $directory/installer*.sh; do
+    case "$file" in
+      (*.min.sh) continue;;
+    esac
+    filename=${file##*/}
+    filename=${filename%.sh}
+    echo "Minifying $directory/$filename.sh"
+    ./minifier.sh -f="$directory/$filename.sh" > "$directory/$filename.min.sh"
+  done
 done


### PR DESCRIPTION
This PR is adding codes to generate platform specific installer files from the TOML files. For example `git/installer.toml` will generate 

1.  `installer.sh`
2.  `installer.min.sh`
3. `installer.apt.sh`
4. `installer.apt.min.sh`
5. `installer.yum.sh`
6. `installer.yum.min.sh`

Likewise for all the installations methods defined in the `installer.toml`

Then the Firebase function is changed to serve the platform-specific scripts if the platform is hinted in the request like 
```
curl https://installer.to/atom?with=apt | bash 
```
If the minified version is needed, then users can hint with `min=yes`
```
curl https://installer.to/atom?min=yes | bash 
```
Both the `with` and `min` flags can be combined. This will give the minified version of the platform specific installer script.
```
curl https://installer.to/atom?with=apt&min=yes | bash 
```

